### PR TITLE
DTO sınıflarında ve ProductService'te kücük dokunuşlar yapıldı

### DIFF
--- a/src/main/java/com/onlineshopping/project2restapi/addDto/CustomerAddDTO.java
+++ b/src/main/java/com/onlineshopping/project2restapi/addDto/CustomerAddDTO.java
@@ -17,11 +17,11 @@ public class CustomerAddDTO {
 
 
     @NotBlank(message = "Name cannot be blank or null")
-    @Size(min = 2, max = 50, message = "Name must be between 2 and 50 characters")
+    @Size(min = 2, max = 16, message = "Name must be between 2 and 16 characters")
     private String name;
 
     @NotBlank(message = "Address cannot be blank or null")
-    @Size(min = 3, max = 100, message = "Address must be between 5 and 100 characters")
+    @Size(min = 3, max = 32, message = "Address must be between 3 and 32 characters")
     private String address;
 
     @NotEmpty(message = "Phone number cannot be empty")

--- a/src/main/java/com/onlineshopping/project2restapi/addDto/OrderAddDTO.java
+++ b/src/main/java/com/onlineshopping/project2restapi/addDto/OrderAddDTO.java
@@ -2,6 +2,7 @@ package com.onlineshopping.project2restapi.addDto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,9 +17,11 @@ public class OrderAddDTO {
     private LocalDateTime date;
 
     @NotBlank(message = "City cannot be blank or null")
+    @Size(min = 3, max = 32, message = "City name must be between 3 and 32 characters")
     private String city;
 
     @NotBlank(message = "Status cannot be blank or null")
+    @Size(min = 3, max = 32, message = "Status must be between 3 and 32 characters")
     private String status;
 
     @NotNull(message = "CustomerId information is required")

--- a/src/main/java/com/onlineshopping/project2restapi/addDto/ProductAddDTO.java
+++ b/src/main/java/com/onlineshopping/project2restapi/addDto/ProductAddDTO.java
@@ -16,10 +16,11 @@ import java.util.Objects;
 @Data
 public class ProductAddDTO {
     @NotBlank(message = "Product name cannot be blank or null")
-    @Size(min = 2, max = 100, message = "Product name must be between 2 and 100 characters")
+    @Size(min = 2, max = 16, message = "Product name must be between 2 and 16 characters")
     private String name;
 
     @NotBlank(message = "Supplier name cannot be blank or null")
+    @Size(min = 2, max = 16, message = "Supplier name must be between 2 and 16 characters")
     private String supplier;
 
     @NotNull(message = "Price cannot be null")

--- a/src/main/java/com/onlineshopping/project2restapi/dto/CustomerDTO.java
+++ b/src/main/java/com/onlineshopping/project2restapi/dto/CustomerDTO.java
@@ -16,11 +16,11 @@ import java.util.Objects;
 public class CustomerDTO {
     private Long id;
     @NotBlank(message = "Name cannot be blank or null")
-    @Size(min = 2, max = 50, message = "Name must be between 2 and 50 characters")
+    @Size(min = 2, max = 16, message = "Name must be between 2 and 16 characters")
     private String name;
 
     @NotBlank(message = "Address cannot be blank or null")
-    @Size(min = 3, max = 100, message = "Address must be between 5 and 100 characters")
+    @Size(min = 3, max = 32, message = "Address must be between 3 and 32 characters")
     private String address;
 
     @NotEmpty(message = "Phone number cannot be empty")

--- a/src/main/java/com/onlineshopping/project2restapi/dto/OrderDTO.java
+++ b/src/main/java/com/onlineshopping/project2restapi/dto/OrderDTO.java
@@ -2,6 +2,7 @@ package com.onlineshopping.project2restapi.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,9 +18,11 @@ public class OrderDTO {
     private LocalDateTime date;
 
     @NotBlank(message = "City cannot be blank or null")
+    @Size(min = 3, max = 32, message = "City name must be between 3 and 32 characters")
     private String city;
 
     @NotBlank(message = "Status cannot be blank or null")
+    @Size(min = 3, max = 32, message = "Status must be between 3 and 32 characters")
     private String status;
 
     @NotNull(message = "Customer information is required")

--- a/src/main/java/com/onlineshopping/project2restapi/dto/ProductDTO.java
+++ b/src/main/java/com/onlineshopping/project2restapi/dto/ProductDTO.java
@@ -1,9 +1,6 @@
 package com.onlineshopping.project2restapi.dto;
 
-import jakarta.validation.constraints.DecimalMin;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,10 +14,11 @@ import java.util.Objects;
 public class ProductDTO {
     private Long id;
     @NotBlank(message = "Product name cannot be blank or null")
-    @Size(min = 2, max = 100, message = "Product name must be between 2 and 100 characters")
+    @Size(min = 2, max = 16, message = "Product name must be between 2 and 16 characters")
     private String name;
 
     @NotBlank(message = "Supplier name cannot be blank or null")
+    @Size(min = 2, max = 16, message = "Supplier name must be between 2 and 16 characters")
     private String supplier;
 
     @NotNull(message = "Price cannot be null")

--- a/src/main/java/com/onlineshopping/project2restapi/service/ProductService.java
+++ b/src/main/java/com/onlineshopping/project2restapi/service/ProductService.java
@@ -55,11 +55,6 @@ public class ProductService {
 
             Product productToUpdate = new Product(id,productUpdateDTO.getName(),productUpdateDTO.getSupplier(),productUpdateDTO.getPrice());
 
-            if(productRepository.checkDuplicateSupplierNamePair(productUpdateDTO.getSupplier() , productUpdateDTO.getName())){
-                throw new DuplicateSupplierNameException("A product with supplier '" + productUpdateDTO.getSupplier()
-                        + "' and name '" + productUpdateDTO.getName() + "' already exists");
-            }
-
 
             return productRepository.save(productToUpdate).viewAsProductDTO();
         }

--- a/src/main/java/com/onlineshopping/project2restapi/updateDto/CustomerUpdateDTO.java
+++ b/src/main/java/com/onlineshopping/project2restapi/updateDto/CustomerUpdateDTO.java
@@ -16,11 +16,11 @@ public class CustomerUpdateDTO {
 
 
     @NotBlank(message = "Name cannot be blank or null")
-    @Size(min = 2, max = 50, message = "Name must be between 2 and 50 characters")
+    @Size(min = 2, max = 16, message = "Name must be between 2 and 16 characters")
     private String name;
 
     @NotBlank(message = "Address cannot be blank or null")
-    @Size(min = 3, max = 100, message = "Address must be between 5 and 100 characters")
+    @Size(min = 3, max = 32, message = "Address must be between 3 and 32 characters")
     private String address;
 
     @NotEmpty(message = "Phone number cannot be empty")

--- a/src/main/java/com/onlineshopping/project2restapi/updateDto/OrderUpdateDTO.java
+++ b/src/main/java/com/onlineshopping/project2restapi/updateDto/OrderUpdateDTO.java
@@ -2,6 +2,7 @@ package com.onlineshopping.project2restapi.updateDto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,9 +17,11 @@ public class OrderUpdateDTO {
     private LocalDateTime date;
 
     @NotBlank(message = "City cannot be blank or null")
+    @Size(min = 3, max = 32, message = "City name must be between 3 and 32 characters")
     private String city;
 
     @NotBlank(message = "Status cannot be blank or null")
+    @Size(min = 3, max = 32, message = "Status must be between 3 and 32 characters")
     private String status;
 
     @NotNull(message = "CustomerId information is required")

--- a/src/main/java/com/onlineshopping/project2restapi/updateDto/ProductUpdateDTO.java
+++ b/src/main/java/com/onlineshopping/project2restapi/updateDto/ProductUpdateDTO.java
@@ -16,10 +16,11 @@ import java.util.Objects;
 @Data
 public class ProductUpdateDTO {
     @NotBlank(message = "Product name cannot be blank or null")
-    @Size(min = 2, max = 100, message = "Product name must be between 2 and 100 characters")
+    @Size(min = 2, max = 16, message = "Product name must be between 2 and 16 characters")
     private String name;
 
     @NotBlank(message = "Supplier name cannot be blank or null")
+    @Size(min = 2, max = 16, message = "Supplier name must be between 2 and 16 characters")
     private String supplier;
 
     @NotNull(message = "Price cannot be null")


### PR DESCRIPTION
###  Açıklama
DTO sınıflarındaki validasyonlar veritabanına uygun hale getirildi.
- Örnek: `name` alanı veritabanında maksimum **16** karakterken validasyon **100** karaktere kadar izin veriyordu. Bu sınır **16** karakter olarak güncellendi.

`ProductService` içindeki `updateProduct` fonksiyonunda aşağıdaki değişiklik yapıldı:
- `checkDuplicateSupplierNamePair` fonksiyonu kaldırıldı.
- Bir ürünün fiyatını değiştirmeye çalışırken hata alınmasına sebep oluyordu.